### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python_ci_workflow.yml
+++ b/.github/workflows/python_ci_workflow.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cshillrj46/SafeTalk-AI/security/code-scanning/2](https://github.com/cshillrj46/SafeTalk-AI/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify `contents: read`, which is sufficient for the current workflow since it only needs to read the repository contents to perform CI tasks. This change ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
