### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/cshillrj46/SafeTalk-AI/security/code-scanning/1](https://github.com/cshillrj46/SafeTalk-AI/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since this is a basic CI workflow that only checks out the repository, installs dependencies, and runs tests, it likely only requires `contents: read` permissions. This ensures that the `GITHUB_TOKEN` has the minimal privileges necessary to perform the workflow tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
